### PR TITLE
better-monadic-for should runsRightAfter the parser phase instead of runsAfter the parser phase

### DIFF
--- a/src/main/scala/com/olegpy/bm4/BetterMonadicFor.scala
+++ b/src/main/scala/com/olegpy/bm4/BetterMonadicFor.scala
@@ -77,6 +77,7 @@ class ForRewriter(plugin: BetterMonadicFor, val global: Global)
   override val noUncheckedFilter: Boolean = plugin.noUncheckedFilter
 
   val runsAfter = "parser" :: Nil
+  override val runsRightAfter = runsAfter
   override val runsBefore = "namer" :: Nil
   val phaseName = "bm4-parser"
 


### PR DESCRIPTION
This commit fixes https://github.com/ThoughtWorksInc/Dsl.scala/issues/113