### PR TITLE
Enable Inlining during compilation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ lazy val betterMonadicFor = (project in file("better-monadic-for"))
     ),
     publishTo := sonatypePublishTo.value,
     publishMavenStyle := true,
-    scalacOptions in Compile ++= Seq("-opt:l:inline", "-opt-inline-from:scala/**"),
+    scalacOptions in Compile ++= Seq("-opt:l:inline", "-opt-inline-from:scala.**"),
     sonatypeProjectHosting := Some(GitHubHosting("oleg-py", "better-monadic-for", "oleg.pyzhcov@gmail.com")),
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ lazy val betterMonadicFor = (project in file("better-monadic-for"))
     ),
     publishTo := sonatypePublishTo.value,
     publishMavenStyle := true,
+    scalacOptions in Compile ++= Seq("-opt:l:inline", "-opt-inline-from:scala/**"),
     sonatypeProjectHosting := Some(GitHubHosting("oleg-py", "better-monadic-for", "oleg.pyzhcov@gmail.com")),
   )
 


### PR DESCRIPTION
When profiling a compilation of `http4s/core`, I noticed that there were several Mb of objects of type `Some`, `Tuple2`, or `Tuple3`, that were created from the `better-monadic-for` plugin.  

In the build of the Scala compiler, the inliner is used to remove and optimise away these small objects. See https://github.com/scala/scala/blob/2.13.x/project/ScriptCommands.scala#L118