### PR TITLE
upgrade to ScalaTest 3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,15 +13,7 @@ ThisBuild / homepage := Some(url("http://github.com/oleg-py/better-monadic-for")
 ThisBuild / scalaVersion := Option(System.getenv("SCALA_VERSION")).filter(_.nonEmpty).getOrElse(scala213)
 
 val testSettings = Seq(
-  libraryDependencies ++= Seq(
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 13)) =>
-        // bincompatible enough :)
-        "org.scalatest" % "scalatest_2.13.0-RC3" % "3.1.0-SNAP12" % Test
-      case _ => "org.scalatest" %% "scalatest" % "3.1.0-SNAP12" % Test
-    }
-   
-  ),
+  libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   Test / scalacOptions ++= {
     val jar = (betterMonadicFor / Compile / packageBin).value
     Seq(s"-Xplugin:${jar.getAbsolutePath}", s"-Jdummy=${jar.lastModified}") // ensures recompile

--- a/cats-tests/src/test/scala/com/olegpy/bm4/CatsSyntaxTest.scala
+++ b/cats-tests/src/test/scala/com/olegpy/bm4/CatsSyntaxTest.scala
@@ -1,10 +1,10 @@
 package com.olegpy.bm4
 
 import cats.Monad
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 import cats.implicits._
 
-class CatsSyntaxTest extends FreeSpec {
+class CatsSyntaxTest extends AnyFreeSpec {
   implicit val mcCatsInstance: cats.FlatMap[MapCheck] = new cats.FlatMap[MapCheck] {
     def flatMap[A, B](fa: MapCheck[A])(f: A => MapCheck[B]): MapCheck[B] = {
       fa.flatMap(f)

--- a/pcplod-tests/src/test/scala/com/olegpy/bm4/PresentationCompiler.scala
+++ b/pcplod-tests/src/test/scala/com/olegpy/bm4/PresentationCompiler.scala
@@ -1,9 +1,9 @@
 package com.olegpy.bm4
 
 import org.ensime.pcplod._
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class PresentationCompiler extends FreeSpec {
+class PresentationCompiler extends AnyFreeSpec {
   "PC should have no errors" in {
     withMrPlod("Arrows.scala") { pc =>
       assert(pc.messages.isEmpty)

--- a/plugin-tests/src/test/scala/com/olegpy/bm4/TestFor.scala
+++ b/plugin-tests/src/test/scala/com/olegpy/bm4/TestFor.scala
@@ -3,7 +3,7 @@ package com.olegpy.bm4
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
-import org.scalatest.{FreeSpec, FunSuite}
+import org.scalatest.freespec.AnyFreeSpec
 
 /** Mo is a lazy monad without `withFilter` */
 sealed trait Mo[A] {
@@ -26,7 +26,7 @@ object Mo {
   val unit: Mo[Unit] = Mo(())
 }
 
-class TestFor extends FreeSpec {
+class TestFor extends AnyFreeSpec {
 
   "Plugin allows" - {
     "destructuring for monads without withFilter" in {

--- a/plugin-tests/src/test/scala/com/olegpy/bm4/TestImplicitPatterns.scala
+++ b/plugin-tests/src/test/scala/com/olegpy/bm4/TestImplicitPatterns.scala
@@ -1,6 +1,6 @@
 package com.olegpy.bm4
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 object CTTest {
   def foo[A]: Mo[A] = for {
@@ -8,7 +8,7 @@ object CTTest {
   } yield implicitly[A]
 }
 
-class TestImplicitPatterns extends FreeSpec {
+class TestImplicitPatterns extends AnyFreeSpec {
   case class ImplicitTest(id: String)
   def typed[A](a: A) = ()
   case class ImplicitTest2(id: String)

--- a/plugin-tests/src/test/scala/com/olegpy/bm4/TestNoMap.scala
+++ b/plugin-tests/src/test/scala/com/olegpy/bm4/TestNoMap.scala
@@ -1,6 +1,6 @@
 package com.olegpy.bm4
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 case class MapCalled() extends Exception
 
@@ -9,7 +9,7 @@ class MapCheck[+A](a: A) {
   def flatMap[B](f: A => MapCheck[B]): MapCheck[B] = f(a)
 }
 
-class TestNoMap extends FreeSpec {
+class TestNoMap extends AnyFreeSpec {
   "emits no map(b => b) in for-comprehension" in {
     for {
       _ <- new MapCheck(42)

--- a/plugin-tests/src/test/scala/com/olegpy/bm4/TestNoTuples.scala
+++ b/plugin-tests/src/test/scala/com/olegpy/bm4/TestNoTuples.scala
@@ -1,10 +1,9 @@
 package com.olegpy.bm4
 
 import com.olegpy.bm4.TestNoTuples.TupleChecker
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-
-class TestNoTuples extends FreeSpec {
+class TestNoTuples extends AnyFreeSpec {
   "Plugin removes tuples produced in binding" - {
     "for single definition" in {
       for {

--- a/scalaz-tests/src/test/scala/com/olegpy/bm4/ScalazSyntaxTest.scala
+++ b/scalaz-tests/src/test/scala/com/olegpy/bm4/ScalazSyntaxTest.scala
@@ -1,9 +1,9 @@
 package com.olegpy.bm4
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 import scalaz._, Scalaz._
 
-class ScalazSyntaxTest extends FreeSpec {
+class ScalazSyntaxTest extends AnyFreeSpec {
   implicit val scalazInstance: Bind[MapCheck] = new Bind[MapCheck] {
     def bind[A, B](fa: MapCheck[A])(f: A => MapCheck[B]): MapCheck[B] = fa.flatMap(f)
 


### PR DESCRIPTION
and avoid deprecated stuff, to pave the way for moving to 3.2

it would be convenient for me in the Scala community build if
this were merged (context is scala/community-build#1172)